### PR TITLE
Add support to templates

### DIFF
--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -1,0 +1,49 @@
+package template
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Template struct {
+	Keyboard Keyboard
+}
+
+type Keyboard struct {
+	Name    string
+	Columns []Column
+	Keys    []Key
+	Mirror  bool
+}
+
+type Column struct {
+	Keys int
+	Step float64
+}
+
+type Key struct {
+	Column int
+	Row    int
+	Step   float64
+	H      float64
+	W      float64
+}
+
+func FromFile(name string) (*Template, error) {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(data)
+}
+
+func Parse(data []byte) (*Template, error) {
+	tpl := Template{}
+
+	err := yaml.Unmarshal(data, &tpl)
+	if err != nil {
+		return nil, err
+	}
+	return &tpl, nil
+}

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -1,0 +1,27 @@
+package template_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mrmarble/zmk-viewer/internal/template"
+)
+
+func Diff(t *testing.T, x interface{}, y interface{}) {
+	t.Helper()
+
+	diff := cmp.Diff(x, y)
+	if diff != "" {
+		t.Fatalf(diff)
+	}
+}
+
+func TestParse(t *testing.T) {
+	tpl, err := template.FromFile("testdata/template.yaml.golden")
+	if err != nil {
+		t.Fatal(err)
+	}
+	Diff(t, tpl.Keyboard.Mirror, false)
+	Diff(t, len(tpl.Keyboard.Columns), 2)
+	Diff(t, tpl.Keyboard.Columns[0].Step, 0)
+}

--- a/internal/template/testdata/template.yaml.golden
+++ b/internal/template/testdata/template.yaml.golden
@@ -1,0 +1,4 @@
+keyboard:
+  columns:
+    - keys: 2
+    - keys: 2


### PR DESCRIPTION
I've created a template system to support custom keyboard layouts that are not available in QMK Toolbox as suggested in #2.

The template uses YAML syntax and is quite simple with a few keywords available, it can be improved with some feedback.

This is an example template for [S'mores Clog](https://www.smoresboards.com/product/clog) keyboard:
```yaml
keyboard:
  name: The Clog # Optinal, currently not used
  mirror: true # To create a split keyboard declaring only the first half
  columns:
    - keys: 1 # Number of keys in the column
      step: 3 # Offset from top
    - keys: 2
      step: 2.5
    - keys: 3
      step: 0.5
    - keys: 3
    - keys: 3
      step: 0.5
    - keys: 4
      step: 0.5
  keys: # To target specific keys that need more personalization. 
    - column: 6 # Thumb key
      row: 2
      step: 0.9
      h: 1.7 # Height of the key. there's also 'w' wor width
```

When running the command `zmk-viewer generate clog --template theClog.yaml` this is the image produced:
![imagen](https://user-images.githubusercontent.com/4268580/161423295-b5b5367e-b2aa-4375-85e7-4a6146fe32cf.png)

It's also possible to use the template to parse `.keymap` files using this syntax: ` zmk-viewer generate clog --template theClog.yaml -f clog.keymap`:
![imagen](https://user-images.githubusercontent.com/4268580/161423325-4c012bc5-7e97-4195-a581-bfd4b57b0016.png)

---
Currently, the template is generated from left to right & top to bottom while the keymap is parsed top to bottom & left to right.
This generates some inconsistencies in weird layouts when the keys are formatted to look like the keyboard, like in _The Clog_:
```c
        MAIN_layer {
            bindings = <
                            &kp W      &kp E       &kp R        &kp T            &kp Y     &kp U      &kp I           &kp O
          &kp Q &kp A       &kp S      &kp D       &lt SYM F    &kp G            &kp H     &lt SYM J  &kp K           &kp L        &kp SQT        &kp P
                &mt LSHFT Z &mt LALT X &mt LCTRL C &mt LGUI V   &kp B            &kp N     &mt RGUI M &mt RCTRL COMMA &mt RALT DOT &mt RSHFT FSLH
                                                   &lt BT ENTER &lt NAV SPACE    &sk RSHFT &kp BSPC
            >;
        };
```
 I'm not sure about how ZMK parses `.keymap` files, if they take in account this order or not.