### PR TITLE
Add sensor-bindings support, also optional fields

### DIFF
--- a/pkg/keymap/parser.go
+++ b/pkg/keymap/parser.go
@@ -17,7 +17,7 @@ type File struct {
 
 	Includes []*Include `parser:"@@+"`
 	Defines  []*Define  `parser:"@@*"`
-	Configs  []*Config  `parser:"@@"`
+	Configs  []*Config  `parser:"@@*"`
 	Device   *Device    `parser:"'/' '{' @@ '}'';'"`
 }
 
@@ -51,7 +51,7 @@ type Value struct {
 type Device struct {
 	Pos lexer.Position
 
-	Combos *Combos `parser:"'combos' '{' @@"`
+	Combos *Combos `parser:"('combos' '{' @@)?"`
 	Keymap *Keymap `parser:"'keymap' '{' @@"`
 }
 
@@ -81,8 +81,10 @@ type Keymap struct {
 type Layer struct {
 	Pos lexer.Position
 
-	Name     string      `parser:"@Ident '{'"`
-	Bindings []*Behavior `parser:"'bindings' '=' '<'@@+'>'';' '}'';'"`
+	Name           string      `parser:"@Ident '{'"`
+	Bindings       []*Behavior `parser:"'bindings' '=' '<'@@+'>'';'"`
+	SensorBindings []*Behavior `parser:"('sensor''-''bindings' '=' '<'@@+'>'';')?"`
+	EndBrace       string      `parser:" '}'';'"`
 }
 
 type List struct {

--- a/pkg/keymap/parser_test.go
+++ b/pkg/keymap/parser_test.go
@@ -104,6 +104,7 @@ var cradioKeymapFile = `
 };
 `
 
+//nolint:lll // ignoring line length because of visual spacing
 var sofleKeymapFile = `/*
 * Copyright (c) 2020 The ZMK Contributors
 *

--- a/pkg/keymap/parser_test.go
+++ b/pkg/keymap/parser_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var keymapFile = `
+var cradioKeymapFile = `
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
@@ -104,10 +104,69 @@ var keymapFile = `
 };
 `
 
+var sofleKeymapFile = `/*
+* Copyright (c) 2020 The ZMK Contributors
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+/ {
+	 keymap {
+			 compatible = "zmk,keymap";
+
+			 default_layer {
+					 bindings = <
+&kp GRAVE &kp N1 &kp N2   &kp N3   &kp N4    &kp N5                      &kp N6 &kp N7    &kp N8    &kp N9   &kp N0   &none
+&kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                       &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
+&kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                       &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
+&kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B  &kp C_MUTE &none     &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
+								&kp LGUI &kp LALT &kp LCTRL &mo 1  &kp RET    &kp SPACE &mo 2  &kp RCTRL &kp RALT  &kp RGUI
+					 >;
+
+					 sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+			 };
+
+			 lower_layer {
+					 bindings = <
+&trans    &kp F1    &kp F2    &kp F3      &kp F4    &kp F5                    &kp F6    &kp F7   &kp F8          &kp F9    &kp F10   &kp F11
+&kp GRAVE &kp N1    &kp N2    &kp N3      &kp N4    &kp N5                    &kp N6    &kp N7   &kp N8          &kp N9    &kp N0    &kp F12
+&trans    &kp EXCL  &kp AT    &kp HASH    &kp DLLR  &kp PRCNT                 &kp CARET &kp AMPS &kp KP_MULTIPLY &kp LPAR  &kp RPAR  &kp PIPE
+&trans    &kp EQUAL &kp MINUS &kp KP_PLUS &kp LBRC  &kp RBRC  &trans   &trans &kp LBKT  &kp RBKT &kp SEMI        &kp COLON &kp BSLH  &trans
+									 &trans    &trans      &trans    &trans    &trans   &trans &trans    &trans   &trans          &trans
+					 >;
+
+					 sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+			 };
+
+			 raise_layer {
+					 bindings = <
+&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4             &trans    &trans    &trans   &trans    &trans  &trans
+&trans     &kp INS      &kp PSCRN    &kp K_CMENU  &trans       &trans                   &kp PG_UP &trans    &kp UP   &trans    &kp N0  &trans
+&trans     &kp LALT     &kp LCTRL    &kp LSHFT    &trans       &kp CLCK                 &kp PG_DN &kp LEFT  &kp DOWN &kp RIGHT &kp DEL &kp BSPC
+&trans     &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &trans  &trans   &trans  &trans    &trans    &trans   &trans    &trans  &trans
+											 &trans       &trans       &trans       &trans  &trans   &trans  &trans    &trans    &trans   &trans
+					 >;
+
+					 sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+			 };
+	 };
+};
+`
+
 func Test(t *testing.T) {
-	r := strings.NewReader(keymapFile)
-	_, err := Parse(r)
-	if err != nil {
-		t.Fatal(err)
+	cradioRaw := strings.NewReader(cradioKeymapFile)
+	_, cradioErr := Parse(cradioRaw)
+	if cradioErr != nil {
+		t.Fatal(cradioErr)
+	}
+
+	sofleRaw := strings.NewReader(sofleKeymapFile)
+	_, sofleErr := Parse(sofleRaw)
+	if sofleErr != nil {
+		t.Fatal(sofleErr)
 	}
 }


### PR DESCRIPTION
# Summary

- added sensor-bindings to the Layer struct
  - moved the EndBrace to a separate field since sensor-bindings is optional
- make the Configs field optional
- make the Combos field optional
- add a test for the default sofle/keyhive keymap



tl;dr I tried to run on the default sofle/keyhive keymap, and it threw up because it didn't have `&mt`, `combos` within the keymap block, and included `sensor-bindings` in the layers. So I added logic to handle each of those, since they all seem to be optional for a functional keymap file.



In checking for those, I saw there are a few more fields that are optional that could get added later, but I've only handled for the ones I've run into and can test.



Thanks for the library!