### PR TITLE
feat: add ability use local info.json file

### DIFF
--- a/internal/lib/generate.go
+++ b/internal/lib/generate.go
@@ -62,21 +62,16 @@ func drawLayout(ctx *gg.Context, transparent bool, layout keyboard.Layout) error
 	}
 
 	for _, key := range layout.Layout {
-		var w float64
-		var h float64
+		w := keySize
+		h := keySize
 		x := key.X*keySize + spacer*key.X + spacer
 		y := key.Y*keySize + spacer*key.Y + (fontSize + spacer*2)
 
 		if key.H != nil {
 			h = *key.H * keySize
-		} else {
-			h = keySize
 		}
-
 		if key.W != nil {
 			w = *key.W * keySize
-		} else {
-			w = keySize
 		}
 
 		ctx.DrawRoundedRectangle(x, y, w, h, spacer)

--- a/internal/lib/generate.go
+++ b/internal/lib/generate.go
@@ -62,20 +62,17 @@ func drawLayout(ctx *gg.Context, transparent bool, layout keyboard.Layout) error
 	}
 
 	for _, key := range layout.Layout {
-		w := keySize
-		h := keySize
 		x := key.X*keySize + spacer*key.X + spacer
 		y := key.Y*keySize + spacer*key.Y + (fontSize + spacer*2)
-
+		w := keySize
+		h := keySize
 		if key.H != nil {
 			h = *key.H * keySize
 		}
 		if key.W != nil {
 			w = *key.W * keySize
 		}
-
 		ctx.DrawRoundedRectangle(x, y, w, h, spacer)
-
 		ctx.SetRGB(0., 0., 0.)
 		ctx.StrokePreserve()
 		ctx.SetRGB(1.0, 1.0, 1.0)

--- a/internal/lib/generate.go
+++ b/internal/lib/generate.go
@@ -62,14 +62,24 @@ func drawLayout(ctx *gg.Context, transparent bool, layout keyboard.Layout) error
 	}
 
 	for _, key := range layout.Layout {
+		var w float64
+		var h float64
 		x := key.X*keySize + spacer*key.X + spacer
 		y := key.Y*keySize + spacer*key.Y + (fontSize + spacer*2)
 
 		if key.H != nil {
-			ctx.DrawRoundedRectangle(x, y, key.W*keySize, *key.H*keySize, spacer)
+			h = *key.H * keySize
 		} else {
-			ctx.DrawRoundedRectangle(x, y, key.W*keySize, keySize, spacer)
+			h = keySize
 		}
+
+		if key.W != nil {
+			w = *key.W * keySize
+		} else {
+			w = keySize
+		}
+
+		ctx.DrawRoundedRectangle(x, y, w, h, spacer)
 
 		ctx.SetRGB(0., 0., 0.)
 		ctx.StrokePreserve()

--- a/internal/lib/root.go
+++ b/internal/lib/root.go
@@ -23,10 +23,18 @@ type GenerateCmd struct {
 func (g *GenerateCmd) Run() error {
 	images := make(map[string]image.Image)
 
-	keyboardInfo, err := keyboard.LoadKeyboard(g.KeyboardName, g.LayoutFile)
+	var keyboardInfo keyboard.Layouts
+	var err error
+	if g.LayoutFile != "" {
+		keyboardInfo, err = keyboard.LoadFile(g.KeyboardName, g.LayoutFile)
+	} else {
+		keyboardInfo, err = keyboard.Fetch(g.KeyboardName)
+	}
+
 	if err != nil {
 		return err
 	}
+
 	g.KeyboardName = strings.ReplaceAll(g.KeyboardName, "/", "_")
 
 	for layoutName, layout := range keyboardInfo {

--- a/internal/lib/root.go
+++ b/internal/lib/root.go
@@ -15,6 +15,7 @@ type GenerateCmd struct {
 	KeyboardName string `arg:"" help:"Keyboard name to fetch layout."`
 
 	File        string `optional:"" short:"f" type:"existingfile" help:"ZMK .keymap file"`
+	LayoutFile  string `optional:"" short:"l" type:"layoutfile" help:"info.json file"`
 	Transparent bool   `optional:"" short:"t" help:"Use a transparent background."`
 	Output      string `optional:"" short:"o" type:"existingdir" default:"." help:"Output directory."`
 }
@@ -22,7 +23,7 @@ type GenerateCmd struct {
 func (g *GenerateCmd) Run() error {
 	images := make(map[string]image.Image)
 
-	keyboardInfo, err := keyboard.Fetch(g.KeyboardName)
+	keyboardInfo, err := keyboard.LoadKeyboard(g.KeyboardName, g.LayoutFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/keyboard/keyboard.go
+++ b/pkg/keyboard/keyboard.go
@@ -14,7 +14,7 @@ import (
 type Key struct {
 	X     float64  `json:"x"`
 	Y     float64  `json:"y"`
-	W     float64  `json:"w"`
+	W     *float64 `json:"w"`
 	H     *float64 `json:"h"`
 	Label string   `json:"label"`
 }

--- a/pkg/keyboard/keyboard.go
+++ b/pkg/keyboard/keyboard.go
@@ -35,10 +35,6 @@ type file struct {
 	Keyboards map[string]Keyboard `json:"keyboards"`
 }
 
-type localfile struct {
-	Layouts map[string]Layout
-}
-
 func fetch(url string) (*file, error) {
 	log.Info().Msg("Fetching keyboard layout.")
 	log.Debug().Str("url", url).Send()
@@ -77,12 +73,12 @@ func fetch(url string) (*file, error) {
 	return &f, nil
 }
 
-func load(path string) (*localfile, error) {
+func load(path string) (*Keyboard, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	f := localfile{}
+	f := Keyboard{}
 	err = json.Unmarshal(data, &f)
 	if err != nil {
 		return nil, err

--- a/pkg/keyboard/keyboard.go
+++ b/pkg/keyboard/keyboard.go
@@ -73,7 +73,7 @@ func fetch(url string) (*file, error) {
 	return &f, nil
 }
 
-func load(path string) (*Keyboard, error) {
+func loadFile(path string) (*Keyboard, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -86,17 +86,8 @@ func load(path string) (*Keyboard, error) {
 	return &f, nil
 }
 
-func LoadKeyboard(name, path string) (Layouts, error) {
+func Fetch(name string) (Layouts, error) {
 	log.Debug().Str("name", name).Send()
-	if path != "" {
-		f, err := load(path)
-		if err != nil {
-			return nil, err
-		}
-		l := f.Layouts
-		return l, nil
-	}
-
 	url := "https://keyboards.qmk.fm/v1/keyboards/%v/info.json"
 
 	f, err := fetch(fmt.Sprintf(url, name))
@@ -106,4 +97,16 @@ func LoadKeyboard(name, path string) (Layouts, error) {
 
 	l := f.Keyboards[name].Layouts
 	return l, nil
+}
+
+func LoadFile(name, path string) (Layouts, error) {
+	log.Debug().Str("name", name).Send()
+	log.Debug().Str("path", path).Send()
+	f, err := loadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	l := f.Layouts
+	return l, nil
+
 }


### PR DESCRIPTION
I have a Kinesis360, which uses zmk. I think that's probably why there's no info.json on the qmk website. However, Kinesis does include an info.json: https://github.com/KinesisCorporation/Adv360-Pro-ZMK/blob/V2.0/config/info.json in their firmware repo.

I added a new parameter `-l` which lets you specify a local info.json file. Without the parameter, the program functions normally.

It seems to work properly. Although you do need to edit the `adv360.keymap` file by deleting this part near the top:
```c
behaviors {
      #include "macros.dtsi"

      hm: homerow_mods {
          compatible = "zmk,behavior-hold-tap";
          label = "HOMEROW_MODS";
          #binding-cells = <2>;
          tapping-term-ms = <200>;
          quick_tap_ms = <175>;
          flavor = "tap-preferred";
          bindings = <&kp>, <&kp>;
      };
    };
``` 

Anyway, not sure this is useful at all to anyone else or not. And also, I don't really kno how to write anything in Go and I'm not at all tuned into the zmk/qmk/custom keyboard community so this is probably very far from perfect. But I figured I'd open up a PR just in case anyone else finds this useful!

![adv360_default_layer](https://user-images.githubusercontent.com/122650661/212440076-d53f3b9e-fdb7-4648-ba7e-08ee269ad209.png)
![adv360_keypad](https://user-images.githubusercontent.com/122650661/212440085-228b24af-0c91-4711-99c2-6a4a651ba27e.png)
![adv360_mod](https://user-images.githubusercontent.com/122650661/212440229-3a34536c-cda9-4d19-9595-a672a96cd2a3.png)

