### PR TITLE
feat(parser): add optional display-name to layer

### DIFF
--- a/pkg/keymap/parser.go
+++ b/pkg/keymap/parser.go
@@ -84,6 +84,7 @@ type Layer struct {
 	Pos lexer.Position
 
 	Name           string      `parser:"@Ident '{'"`
+	DisplayName    string      `parser:"('display-name' '=' @String';')?"`
 	Bindings       []*Behavior `parser:"'bindings' '=' '<'@@+'>'';'"`
 	SensorBindings []*Behavior `parser:"('sensor''-''bindings' '=' '<'@@+'>'';')?"`
 	EndBrace       string      `parser:" '}'';'"`


### PR DESCRIPTION
My keymap was failing with `sub-expression Layer+ must match at least once`. Turns out it was because I have a label assigned to each layer in my keymap which is used in ZMK to show the current layer on displays via widget.

My keymap layers start like this

```
default_layer {
    label = "Base";
    bindings = <
```

This change adds support for an optional label property in layers which can match zero or once. Potentially the label could be used to print on the images in the top left corner rather than the layer identifier of the keymap.

See https://github.com/zmkfirmware/zmk/pull/551 which is the merged change in ZMK to support using the label to show in display widgets. There is also https://github.com/zmkfirmware/zmk/issues/578 which is to document this optional layer.